### PR TITLE
Update core.clj

### DIFF
--- a/src/glimmer/core.clj
+++ b/src/glimmer/core.clj
@@ -96,7 +96,7 @@
       (t/move-cursor term (:x (:cursor state)) (:y (:cursor state))))))
 
 (defn -get-lines
-  "Returns an array of lines, given a file path"
+  "Returns an array of lines from a file, given a file path"
   [file-path]
   (clojure.string/split-lines (slurp file-path)))
 


### PR DESCRIPTION
A crucial fix to the authenticity of the documentation. This change allows the world to see EXACTLY what where the code gets an array of lines from. Simply saying it takes a file path is NOT ENOUGH, what if it returned an array of lines from the line breaks in file path itself? It is VERY important. VERY. 